### PR TITLE
Set GOROOT if it is not set

### DIFF
--- a/golint/creator/creator.go
+++ b/golint/creator/creator.go
@@ -15,23 +15,27 @@
 package creator
 
 import (
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/palantir/godel-okgo-asset-golint/golint"
 	"github.com/palantir/okgo/checker"
 	"github.com/palantir/okgo/okgo"
 )
 
-func Golint(cpuProfileFlagVal string) checker.Creator {
+func Golint() checker.Creator {
 	return checker.NewCreator(
 		golint.TypeName,
 		golint.Priority,
 		func(cfgYML []byte) (okgo.Checker, error) {
-			params := []checker.AmalgomatedCheckerParam{
-				checker.ParamPriority(golint.Priority),
+			// set GOROOT environment variable if it is not set
+			if _, ok := os.LookupEnv("GOROOT"); !ok {
+				if gorootOutput, err := exec.Command("go", "env", "GOROOT").CombinedOutput(); err == nil {
+					_ = os.Setenv("GOROOT", strings.TrimSpace(string(gorootOutput)))
+				}
 			}
-			if cpuProfileFlagVal != "" {
-				params = append(params, checker.ParamArgs("--cpuprofile-private", cpuProfileFlagVal))
-			}
-			return checker.NewAmalgomatedChecker(golint.TypeName, params...), nil
+			return checker.NewAmalgomatedChecker(golint.TypeName, checker.ParamPriority(golint.Priority)), nil
 		},
 	)
 }

--- a/main.go
+++ b/main.go
@@ -15,9 +15,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"runtime/pprof"
 
 	"github.com/palantir/amalgomate/amalgomated"
 	amalgomatedcheck "github.com/palantir/godel-okgo-asset-golint/generated_src"
@@ -27,55 +25,12 @@ import (
 	"github.com/palantir/pkg/cobracli"
 )
 
-const (
-	cpuProfilePublicFlagName  = "cpuprofile"
-	cpuProfilePrivateFlagName = "cpuprofile-private"
-)
-
 func main() {
-	os.Exit(runMain())
-}
-
-// runMain is the functional equivalent of the main function and returns an int exit code. Making this a separate
-// function ensures that the defer call is executed before the program exits (os.Exit does not run deferred functions).
-func runMain() int {
-	// if cpuProfilePrivateFlagName flag is present, profile
-	if cpuProfileFlagVal, osArgs := getFlagVal(cpuProfilePrivateFlagName, os.Args); cpuProfileFlagVal != "" {
-		f, err := os.Create(cpuProfileFlagVal)
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to create CPU profile: %v\n", err)
-			return 1
-		}
-		if err := pprof.StartCPUProfile(f); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to start CPU profile: %v\n", err)
-			return 1
-		}
-		defer func() {
-			pprof.StopCPUProfile()
-			if err := f.Close(); err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "Failed to close CPU profile file: %v\n", err)
-			}
-		}()
-		os.Args = osArgs
-	}
-	return amalgomated.RunApp(os.Args, nil, amalgomated.NewCmdLibrary(amalgomatedcheck.Instance()), checkMain)
+	os.Exit(amalgomated.RunApp(os.Args, nil, amalgomated.NewCmdLibrary(amalgomatedcheck.Instance()), checkMain))
 }
 
 func checkMain(osArgs []string) int {
-	var cpuProfileFlagVal string
-	cpuProfileFlagVal, osArgs = getFlagVal(cpuProfilePublicFlagName, osArgs)
 	os.Args = osArgs
-	rootCmd := checker.AssetRootCmd(creator.Golint(cpuProfileFlagVal), config.UpgradeConfig, "run golint check")
+	rootCmd := checker.AssetRootCmd(creator.Golint(), config.UpgradeConfig, "run golint check")
 	return cobracli.ExecuteWithDefaultParams(rootCmd)
-}
-
-func getFlagVal(flagName string, osArgs []string) (flagVal string, osArgsWithFlagAndValRemoved []string) {
-	for idx, arg := range osArgs {
-		if arg == "--"+flagName && idx+1 < len(osArgs) {
-			flagVal = osArgs[idx+1]
-			osArgs = append(osArgs[:idx], osArgs[idx+2:]...)
-			break
-		}
-	}
-	return flagVal, osArgs
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates `golint` check to set the GOROOT environment variable to the output of `go env GOROOT` if it is not set. This fixes an issue where, otherwise, GOROOT would fall back to the value set by the `go` executable when the check was built, which is not helpful.

Also removes the flag to profile the check.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

